### PR TITLE
Bug in Badge.js for iPhone that overwrites window.plugins

### DIFF
--- a/iPhone/Badge/Badge.js
+++ b/iPhone/Badge/Badge.js
@@ -29,9 +29,8 @@ Badge.prototype.clear = function() {
 
 PhoneGap.addConstructor(function() 
 {
-	if(window.plugins)
-	{
-		window.plugins = {};
-	}
+    if (!window.plugins) {
+      window.plugins = {};
+    }
     window.plugins.badge = new Badge();
 });

--- a/iPhone/EmailComposer/readme.txt
+++ b/iPhone/EmailComposer/readme.txt
@@ -1,23 +1,9 @@
-{\rtf1\ansi\ansicpg1252\cocoartf1038\cocoasubrtf290
-{\fonttbl\f0\fswiss\fcharset0 ArialMT;}
-{\colortbl;\red255\green255\blue255;}
-\margl1440\margr1440\vieww12240\viewh15840\viewkind1
-\deftab720
-\pard\pardeftab720\ql\qnatural
 
-\f0\fs26 \cf0 \
-\
 You will need to add MessageUI.framework to your project if it is not already included.\
-\
-\pard\pardeftab720\ql\qnatural
-\cf0 Just add the .m.h files to your project ( you can add them directly to your own project, you don't need to put them in phonegap lib ).\
-\
-Place the .js file in your app root, and include it from your html.\
-\
-This is intended to also demonstrate how to pass arguments to native code using the options/map object. \'a0Please review the js file to understand the interface you can call, and reply with any questions.\
-\pard\pardeftab720\ql\qnatural
-\cf0 \
-\
-\
-\
-}
+
+Just add the .m.h files to your project ( you can add them directly to your own project, you don't need to put them in phonegap lib ).
+
+Place the .js file in your app root, and include it from your html.
+
+This is intended to also demonstrate how to pass arguments to native code using the options/map object. 
+Please review the js file to understand the interface you can call, and reply with any questions.

--- a/iPhone/EmailComposer/readme.txt
+++ b/iPhone/EmailComposer/readme.txt
@@ -1,5 +1,4 @@
-
-You will need to add MessageUI.framework to your project if it is not already included.\
+You will need to add MessageUI.framework to your project if it is not already included.
 
 Just add the .m.h files to your project ( you can add them directly to your own project, you don't need to put them in phonegap lib ).
 


### PR DESCRIPTION
Instead of testing `!window.plugins`, this plugin was only initializing it if it _already_ existed, and wouldn't initialize if it wasn't. This patch fixes that and cleans up the whitespace and hanging brace to match the rest of the file.
