### PR TITLE
Show atbottom

### DIFF
--- a/AdPlugin/iOS/SAiOSAdPlugin.js
+++ b/AdPlugin/iOS/SAiOSAdPlugin.js
@@ -8,9 +8,10 @@ function SAiOSAdPlugin()
 /**
  * show - true to show the ad, false to hide the ad
  */
-SAiOSAdPlugin.prototype.showAd = function(show)
+SAiOSAdPlugin.prototype.showAd = function(show, atBottom)
 {
-	PhoneGap.exec("SAiOSAdPlugin.showAd", show);
+    if (!atBottom) atBottom = false;
+    PhoneGap.exec("SAiOSAdPlugin.showAd", show, atBottom);
 }
 
 /**
@@ -18,10 +19,8 @@ SAiOSAdPlugin.prototype.showAd = function(show)
  */
 SAiOSAdPlugin.prototype.prepare = function(atBottom)
 {
-	if (!atBottom) {
-		atBottom = false;
-	}
-	PhoneGap.exec("SAiOSAdPlugin.prepare", atBottom);
+    if (!atBottom) atBottom = false;
+    PhoneGap.exec("SAiOSAdPlugin.prepare", atBottom);
 }
 
 /**
@@ -29,12 +28,8 @@ SAiOSAdPlugin.prototype.prepare = function(atBottom)
  */
 SAiOSAdPlugin.install = function()
 {
-	if ( !window.plugins ) 
-		window.plugins = {}; 
-	if ( !window.plugins.iAdPlugin ) 
-		window.plugins.iAdPlugin = new SAiOSAdPlugin();
-	
-	
+    if (!window.plugins) window.plugins = {}; 
+    if (!window.plugins.iAdPlugin) window.plugins.iAdPlugin = new SAiOSAdPlugin();
 }
 
 /**

--- a/AdPlugin/iOS/SAiOSAdPlugin.m
+++ b/AdPlugin/iOS/SAiOSAdPlugin.m
@@ -125,7 +125,7 @@
 	[UIView beginAnimations:@"blah" context:NULL];
 	[UIView setAnimationCurve:UIViewAnimationCurveEaseInOut];
 	
-	if (show)
+	if (show && self.bannerView.bannerLoaded)
 	{
 		CGFloat bannerHeight = 50.0;
 		


### PR DESCRIPTION
Hi guys,

I just updated the code of iAd plugin a bit to support the simplified calling, like showAd(true, true) (where the second parameter is atBottom).

It's very convenient when you have multiple pages where you want your ads shown and hidden. When moving between those pages I just call showAd(true, true) and showAd(false) as appropriate. It won't display the Ad if it's not loaded yet. The plugin will still fire callbacks on success and failure and then showAd(true / false) can be called to show / hide the Ad. This change makes it a one-step shop for showing / hiding Ads without making an extra prepare() call.

I was also thinking of automating it a bit and show the ad after initial loading automatically (and hide it on failure), leaving the callback to something else the app needs to do since showing / hiding is necessary pretty much every time. Does it make sense?

Also, pardon me, but I cleaned up the code base a bit (where our roads crossed basically). In fact, Xcode 4 made most of whitespace changes.

Cheers!

(Sorry for the previous -- closed -- pull request. It was for the wrong branch and also didn't include one important commit.)
