### PR TITLE
Return base64 option and new function to save to docs path

### DIFF
--- a/iPhone/ScreenShot/README
+++ b/iPhone/ScreenShot/README
@@ -1,0 +1,31 @@
+This plugin lets you take a screenshot of the viewable screen in iOS without the top status bar.
+
+You can call this function with
+
+window.navigator.saveScreenshot( bool returnBase64, [string successCallbackString] )
+
+or
+
+PhoneGap.exec("Screenshot.saveScreenshot", returnBase64, [ successCallbackString ] );
+
+Where 
+
+returnBase64 (PNG format for now) is a BOOL to say whether or not we return a base64 encoded string back to Javascript or just let the screenshot get saved to the devices Saved Photos.
+
+and
+
+the optional successCallbackString which is the function that will be called  with the returned base64 encoded string given as the only parameter.
+
+So I used this with something like É
+
+É.
+<button onclick="takeScreenshot();">Take Screenshot</button>
+
+function takeScreenShot() {
+    	PhoneGap.exec("Screenshot.saveScreenshot", true, "returnScreenshotImage");		    	
+}	
+	
+function returnScreenshotImage(image) {		
+	base64string = "data:image/png;base64,"+image;
+	$("#image_container").css("background-image", "url("+base64string+")");		 				
+}

--- a/iPhone/ScreenShot/README
+++ b/iPhone/ScreenShot/README
@@ -29,3 +29,10 @@ function returnScreenshotImage(image) {
 	base64string = "data:image/png;base64,"+image;
 	$("#image_container").css("background-image", "url("+base64string+")");		 				
 }
+
+==========================
+Added ability to save screenshot as file to the docs path of the application
+
+saveScreenshotAsFile( fileName, callBackSuccessString )
+
+will call the given return function and pass the filename that was written

--- a/iPhone/ScreenShot/ScreenShot.h
+++ b/iPhone/ScreenShot/ScreenShot.h
@@ -13,4 +13,5 @@
 }
 
 - (void)saveScreenshot:(NSArray*)arguments withDict:(NSDictionary*)options;
+- (void)saveScreenshotAsFile:(NSArray*)arguments withDict:(NSDictionary*)options;
 @end

--- a/iPhone/ScreenShot/ScreenShot.js
+++ b/iPhone/ScreenShot/ScreenShot.js
@@ -19,8 +19,8 @@ Screenshot.prototype.saveScreenshot = function( returnBase64, successCallbackStr
     PhoneGap.exec("Screenshot.saveScreenshot", returnBase64, successCallbackString );
 };
 
-Screenshot.prototype.saveScreenshot = function( fileName, successCallbackString) {
-    PhoneGap.exec("Screenshot.saveScreenshotAsFile", fileName, successCallbackString );
+Screenshot.prototype.saveScreenshotAsFile = function( fileName, successCallbackString, returnBase64 ) {
+    PhoneGap.exec("Screenshot.saveScreenshotAsFile", fileName, successCallbackString, returnBase64 );
 };
 
 PhoneGap.addConstructor(function() 

--- a/iPhone/ScreenShot/ScreenShot.js
+++ b/iPhone/ScreenShot/ScreenShot.js
@@ -15,8 +15,8 @@ function Screenshot() {
 /**
  * Save the screenshot to the user's Photo Library
  */
-Screenshot.prototype.saveScreenshot = function() {
-    PhoneGap.exec("Screenshot.saveScreenshot");
+Screenshot.prototype.saveScreenshot = function( returnBase64, successCallbackString) {
+    PhoneGap.exec("Screenshot.saveScreenshot", returnBase64, successCallbackString );
 };
 
 PhoneGap.addConstructor(function() 

--- a/iPhone/ScreenShot/ScreenShot.js
+++ b/iPhone/ScreenShot/ScreenShot.js
@@ -19,6 +19,10 @@ Screenshot.prototype.saveScreenshot = function( returnBase64, successCallbackStr
     PhoneGap.exec("Screenshot.saveScreenshot", returnBase64, successCallbackString );
 };
 
+Screenshot.prototype.saveScreenshot = function( fileName, successCallbackString) {
+    PhoneGap.exec("Screenshot.saveScreenshotAsFile", fileName, successCallbackString );
+};
+
 PhoneGap.addConstructor(function() 
 {
 	if(!window.plugins)

--- a/iPhone/ScreenShot/ScreenShot.m
+++ b/iPhone/ScreenShot/ScreenShot.m
@@ -11,6 +11,17 @@
 
 - (void)saveScreenshot:(NSArray*)arguments withDict:(NSDictionary*)options
 {
+	NSUInteger argc = [arguments count];
+	NSString* successCallback = nil, *returnBase64 = false;		
+	
+	if (argc > 0) returnBase64 = [arguments objectAtIndex:0];
+	if (argc > 1) successCallback = [arguments objectAtIndex:1];
+	
+	if (argc < 1) {
+		NSLog(@"Screenshot.saveScreenshot: Missing 1st parameter.");
+		return;
+	}
+	
 	CGRect screenRect = [[UIScreen mainScreen] bounds];
 	CGRect imageRect = CGRectMake(0, 0, CGRectGetWidth(screenRect), CGRectGetHeight(screenRect));
 	UIGraphicsBeginImageContext(imageRect.size);
@@ -23,10 +34,27 @@
 	[webView.layer renderInContext:ctx];
 	
 	UIImage *image1 = UIGraphicsGetImageFromCurrentImageContext();
-	UIImageWriteToSavedPhotosAlbum(image1, nil, nil, nil);
+	
+	if (returnBase64) {
+		if (argc < 2) {
+			NSLog(@"Screenshot.saveScreenshot: Missing 2nd parameter.");
+			UIGraphicsEndImageContext();
+			return;
+		} else {
+			NSData *imageData = UIImagePNGRepresentation(image1);
+			NSString *encodedString = [imageData base64Encoding];
+			NSString *jsCallBack;
+			jsCallBack = [ NSString stringWithFormat:@"%@(\"%@\");", successCallback, encodedString ];
+			[webView stringByEvaluatingJavaScriptFromString:jsCallBack];
+		}
+	} else {		
+		UIImageWriteToSavedPhotosAlbum(image1, nil, nil, nil);
+		
+		UIAlertView *alert= [[UIAlertView alloc] initWithTitle:nil message:@"Image Saved" delegate:self cancelButtonTitle:@"OK" otherButtonTitles:nil];
+		[alert show];
+		[alert release];
+	}
+	
 	UIGraphicsEndImageContext();
-	UIAlertView *alert= [[UIAlertView alloc] initWithTitle:nil message:@"Image Saved" delegate:self cancelButtonTitle:@"OK" otherButtonTitles:nil];
-	[alert show];
-	[alert release];
 }
 @end

--- a/iPhone/ScreenShot/ScreenShot.m
+++ b/iPhone/ScreenShot/ScreenShot.m
@@ -61,7 +61,7 @@
 - (void)saveScreenshotAsFile:(NSArray*)arguments withDict:(NSDictionary*)options
 {
 	NSUInteger argc = [arguments count];
-	NSString* successCallback = nil, *fileName = nil;		
+	NSString* successCallback = nil, *fileName = nil, *returnBase64, *encodedString = "false";		
 	
 	if (argc < 2) {
 		NSLog(@"Screenshot.saveScreenshotAsFile: Not Enough Parameters.");
@@ -69,6 +69,7 @@
 	} else {
 		fileName = [arguments objectAtIndex:0];
 		successCallback = [arguments objectAtIndex:1];
+		returnBase64 = [arguments objectAtIndex:2];
 	}
 	
 	CGRect screenRect = [[UIScreen mainScreen] bounds];
@@ -81,12 +82,20 @@
 	[webView.layer renderInContext:ctx];
 	
 	UIImage *image1 = UIGraphicsGetImageFromCurrentImageContext();
+	
+	if (returnBase64) {
+		NSData *imageData = UIImagePNGRepresentation(image1);
+		encodedString = [imageData base64Encoding];
+	} else {
+		encodedString = "false";
+	}
+	
 	UIGraphicsEndImageContext();
 	
 	[UIImagePNGRepresentation(image1) writeToFile:fileName atomically:YES];
 	
 	NSString *jsCallBack;
-	jsCallBack = [ NSString stringWithFormat:@"%@(\"%@\");", successCallback, fileName ];
+	jsCallBack = [ NSString stringWithFormat:@"%@(\"%@\", \"%@\");", successCallback, fileName, encodedString ];
 	[webView stringByEvaluatingJavaScriptFromString:jsCallBack];	
 }
 @end

--- a/iPhone/ScreenShot/ScreenShot.m
+++ b/iPhone/ScreenShot/ScreenShot.m
@@ -57,4 +57,36 @@
 	
 	UIGraphicsEndImageContext();
 }
+
+- (void)saveScreenshotAsFile:(NSArray*)arguments withDict:(NSDictionary*)options
+{
+	NSUInteger argc = [arguments count];
+	NSString* successCallback = nil, *fileName = nil;		
+	
+	if (argc < 2) {
+		NSLog(@"Screenshot.saveScreenshotAsFile: Not Enough Parameters.");
+		return;
+	} else {
+		fileName = [arguments objectAtIndex:0];
+		successCallback = [arguments objectAtIndex:1];
+	}
+	
+	CGRect screenRect = [[UIScreen mainScreen] bounds];
+	CGRect imageRect = CGRectMake(0, 0, CGRectGetWidth(screenRect), CGRectGetHeight(screenRect));
+	UIGraphicsBeginImageContext(imageRect.size);	
+	CGContextRef ctx = UIGraphicsGetCurrentContext();
+	[[UIColor blackColor] set];
+	CGContextTranslateCTM(ctx, 0, 0);
+	CGContextFillRect(ctx, imageRect);	
+	[webView.layer renderInContext:ctx];
+	
+	UIImage *image1 = UIGraphicsGetImageFromCurrentImageContext();
+	UIGraphicsEndImageContext();
+	
+	[UIImagePNGRepresentation(image1) writeToFile:fileName atomically:YES];
+	
+	NSString *jsCallBack;
+	jsCallBack = [ NSString stringWithFormat:@"%@(\"%@\");", successCallback, fileName ];
+	[webView stringByEvaluatingJavaScriptFromString:jsCallBack];	
+}
 @end


### PR DESCRIPTION
Allow screenshot plugin to optionally return a base64 encoded string to a given function name. 
Added a README for the screenshot plugin.
Added a function to save the screenshot as a png file to the app docs path. Additionally this function can return the base64 version of the string which was handy to do an upload to a remote server.
